### PR TITLE
fix(observability): wire up SLO metrics, queue depth, and fix metric naming

### DIFF
--- a/docs/observability/OBSERVABILITY_GUIDE.md
+++ b/docs/observability/OBSERVABILITY_GUIDE.md
@@ -87,10 +87,11 @@ This guide covers the complete observability setup for the Imagen platform.
 | `imagen_jobs_completed_total` | Counter | job_type, status | Jobs processed |
 | `imagen_job_processing_seconds` | Histogram | job_type | Processing duration |
 | `imagen_jobs_in_progress` | Gauge | job_type | Active jobs |
-| `imagen_model_load_seconds` | Histogram | model_name | Model load time |
+| `imagen_triton_inference_seconds` | Histogram | model_name | Pure Triton inference time |
 | `imagen_worker_errors_total` | Counter | job_type, error_type | Worker errors |
 | `imagen_job_slo_met_total` | Counter | job_type | Jobs within SLO |
 | `imagen_job_slo_violated_total` | Counter | job_type | Jobs exceeding SLO |
+| `imagen_queue_depth` | Gauge | queue_name | Current queue depth |
 
 ### Recording Rules (Pre-computed)
 
@@ -289,7 +290,7 @@ kubectl describe pod -n imagen -l app=upscale-worker
 
 ### Adjusting SLOs
 
-Edit `src/workers/base.py`:
+Edit `src/workers/triton_worker.py`:
 
 ```python
 SLO_THRESHOLDS = {
@@ -313,11 +314,11 @@ k8s/monitoring/
 └── README.md                # Detailed documentation
 
 src/api/middleware/
-├── metrics.py               # API Prometheus metrics
+├── metrics.py               # API Prometheus metrics (requests, job creation)
 └── logging.py               # Structured logging
 
 src/workers/
-└── base.py                  # Worker metrics (updated)
+└── triton_worker.py         # Worker metrics (job completion, SLO, queue depth)
 ```
 
 ---


### PR DESCRIPTION
BREAKING CHANGE: Worker metrics now use 'imagen_' prefix instead of 'imagen_triton_'
to match alerting rules in k8s/monitoring/rules.yaml.

Fixes:
- Add SLO tracking with configurable thresholds per job type
- Add imagen_job_slo_met_total and imagen_job_slo_violated_total counters
- Add queue depth monitoring with background thread (30s interval)
- Add imagen_triton_inference_seconds histogram for pure inference latency
- Remove orphaned metrics from API (job completion tracked by workers only)
- Fix metric prefix mismatch (imagen_triton_* -> imagen_*)
- Update documentation to reflect actual implementation

SLO Thresholds:
- upscale: 30s
- enhance: 45s
- style-comic: 60s
- style-aged: 60s
- background-remove: 15s